### PR TITLE
query: use prefix flag

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -310,6 +310,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "62cf9a2b453c665e05fc25a644aa841c4c1ede909941ecf1bb5ee6a0f8c0406a"
+  inputs-digest = "b5bc0bd67df26fd038655d02b8aebe868011abf32985351a2890d1fcad246891"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ gcloud auth applicatiom-default login
 ### Usage
 
 ```
-qbt [--project=<project id>] [--instance=<instance id>] query <table> <query>
+qbt [--project=<project id>] [--instance=<instance id>] [--prefix=<row key prefix>] query <table> <query>
 ```
 
 ### Example
@@ -42,7 +42,7 @@ qbt query my_table '
 
 ### Configuration
 
-Configuration can also be provided from the environment by providing the `QBT_PROJECT` and `QBT_INSTANCE` environment variables, or via CLI flags.
+Configuration can also be provided from the environment by providing the `QBT_PROJECT`, `QBT_INSTANCE`, and `QBT_PREFIX` environment variables, or via CLI flags.
 
 ### Libraries used
 
@@ -61,7 +61,7 @@ Configuration can also be provided from the environment by providing the `QBT_PR
 - [ ] Add debug logging
 - [ ] Queries from file / STDIN
 - [ ] Pre-query scripts (eg. to define functions)
-- [ ] Add CLI params for specifying range / prefix queries
+- [x] Add CLI params for specifying range / prefix queries
 - [ ] Web server for submitting queries to
 - [ ] Other authentication methods
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -14,6 +14,9 @@ type Config struct {
 	// Emulator is the address of a BigTable emulator
 	// instance and project are ignored when an emulator is provided
 	Emulator string
+
+	// Prefix is the row key prefix to predicate upon table scan
+	Prefix string
 }
 
 func loadConfig() Config {

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -15,6 +15,7 @@ func queryBigtable(cmd *cobra.Command, args []string) {
 	config := loadConfig()
 
 	var client *bt.Client
+	var rowRange bt.RowSet
 	var err error
 
 	if config.Emulator != "" {
@@ -27,6 +28,13 @@ func queryBigtable(cmd *cobra.Command, args []string) {
 		fmt.Printf("error: %v\n", err)
 		return
 	}
+
+	if config.Prefix != "" {
+		rowRange = bt.PrefixRange{Prefix: config.Prefix}
+	} else {
+		rowRange = bt.AllRows{}
+	}
+
 	luaenv := lua.NewEnvironment()
 
 	table := args[0]
@@ -34,7 +42,7 @@ func queryBigtable(cmd *cobra.Command, args []string) {
 
 	query := bt.Query{
 		Table:     table,
-		Range:     bt.AllRows{},
+		Range:     rowRange,
 		Predicate: luaenv.RowPredicate(luaQuery),
 	}
 


### PR DESCRIPTION
## Why

The query command had a prefix flag, but the flag's value wasn't persisted in the config, nor was it  used by the query command.

## What

- Persist `Prefix` in `Config`
- When present, use `Config.Prefix` as the `Prefix` of a `bt.PrefixRange` for the query. Otherwise, use `bt.AllRows`
- Updated README accordingly